### PR TITLE
Avoid TypeError: must be str, not bytes when the request fails

### DIFF
--- a/python/fasta.py
+++ b/python/fasta.py
@@ -101,7 +101,8 @@ def restRequest(url):
         reqH.close()
     # Errors are indicated by HTTP status codes.
     except HTTPError as ex:
-        result = requests.get(url).content
+        resp = requests.get(url).content
+        result = unicode(resp, u'utf-8')
     printDebugMessage(u'restRequest', u'End', 11)
     return result
 


### PR DESCRIPTION
(Reopening #8 as a new PR as it was closed following moving around branches)

I have been seeing the following (non reproducible) error message from time to time with the fasta.py script:

```
Traceback (most recent call last):
  File "fasta.py", line 848, in <module>
    getResult(jobId)
  File "fasta.py", line 471, in getResult
    clientPoll(jobId)
  File "fasta.py", line 455, in clientPoll
    result = serviceGetStatus(jobId)
  File "fasta.py", line 382, in serviceGetStatus
    printDebugMessage(u'serviceGetStatus', u'status: ' + status, 2)
TypeError: must be str, not bytes
```

The `restRequest` function returns a `str` when the request succeeds. When the request fails, an additional call to `requests.get(url)` is performed, and the raw response `.content` is returned as `bytes` instead, without conversion.

This PR converts the content to a `str` also in case of failure.

PS: not sure if returning the error contents is the right thing to do in this context, but that's an other story.